### PR TITLE
issue 20/sticky navbar

### DIFF
--- a/components/features/Navbar.tsx
+++ b/components/features/Navbar.tsx
@@ -19,7 +19,7 @@ const Navbar = () => {
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   return (
-    <Box>
+    <Box sx={{ position: 'fixed', right: 0, zIndex: 1 }}>
       <SpeedDial
         direction="down"
         ariaLabel="Navbar"


### PR DESCRIPTION
This PR fixes a bug where navigation button is not fixed on the top of the right.

https://github.com/kaulfield23/Days-of-planty-next.js/assets/77925373/58bed82f-0004-4953-a08a-8a3e964ed741

Resolves #20 

