### PR TITLE
Issue 32/diary section

### DIFF
--- a/app/api/diary/route.ts
+++ b/app/api/diary/route.ts
@@ -1,6 +1,6 @@
 import clientPromise from 'lib/mongo';
 import { plantDiary } from 'lib/mongo/models';
-import { diarySchema } from 'lib/mongo/shcema';
+import { NextRequest } from 'next/server';
 
 export async function POST(request: Request) {
   const client = await clientPromise;
@@ -15,6 +15,22 @@ export async function POST(request: Request) {
     return new Response('Post succeeded', {
       status: 200,
     });
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const client = await clientPromise;
+  const db = client.db('planty');
+  const plantId = request.nextUrl.searchParams.get('plantId');
+
+  try {
+    const result = await db
+      .collection('diary')
+      .find({ plantId: plantId })
+      .toArray();
+    return new Response(JSON.stringify(result));
   } catch (e) {
     console.log(e);
   }

--- a/app/plants/[plantName]/page.tsx
+++ b/app/plants/[plantName]/page.tsx
@@ -75,7 +75,7 @@ const PlantDetail = () => {
               />
             </Box>
             <Box sx={PlantDetailStyle.infoBox}>
-              <Box>
+              <Box sx={PlantDetailStyle.info}>
                 <Box display="flex" justifyContent="center" alignItems="end">
                   <Typography
                     variant="h4"
@@ -213,9 +213,9 @@ const PlantDetail = () => {
                 orientation="vertical"
                 variant="middle"
                 flexItem
-                sx={{ bgcolor: 'white', mx: { xs: 0.8, sm: 2 } }}
+                sx={{ bgcolor: 'white', mx: { xs: 0.8, sm: 1 } }}
               />
-              <Diary />
+              <Diary plantId={plantId} />
               <DiaryBtn />
             </Box>
           </Box>

--- a/components/features/plant/PlantCard.tsx
+++ b/components/features/plant/PlantCard.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Card,
-  CardActionArea,
   CardContent,
   CardMedia,
   CircularProgress,
@@ -62,7 +61,7 @@ const PlantCard = ({ plants }: PlantCardProps) => {
                   />
                   <CardMedia
                     component="img"
-                    height={isMobileSize ? 350 : 450}
+                    height={isMobileSize ? 300 : 450}
                     image={`/static/img/${plant.imgName}.png`}
                     alt={plant.name}
                   />

--- a/components/features/plant/diary/Diary.tsx
+++ b/components/features/plant/diary/Diary.tsx
@@ -1,15 +1,31 @@
-import { Box, Button, Typography } from '@mui/material';
-import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useState } from 'react';
 import { DiaryStyle } from 'styles/DiaryStyle';
+import { DiaryTypes } from 'utils/types';
 
-const Diary = () => {
+interface DiaryProps {
+  plantId: string | null;
+}
+
+const Diary = ({ plantId }: DiaryProps) => {
+  const [logs, setLogs] = useState<DiaryTypes>();
+
+  const fetchDiary = () => {
+    fetch(`/api/diary?plantId=${plantId}`, {
+      method: 'GET',
+    })
+      .then((res) => res.json())
+      .then((data) => console.log(setLogs(data)));
+  };
+  console.log(logs);
+
   return (
     <Box sx={DiaryStyle.diaryBox}>
-      <Typography>
-        blah blah bah blah blah bah blah blah bah blah blah bahblah blah bah
-        blah blah bah blah blah bah blah blah bah blah blah bah blah blah bah
-        blah blah bahblah blah bah blah blah bah blah blah bah{' '}
-      </Typography>
+      <Box sx={DiaryStyle.diarySection} onClick={fetchDiary}>
+        <Typography variant="h4" color="customBlack.main">
+          Log
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/components/features/plant/diary/Diary.tsx
+++ b/components/features/plant/diary/Diary.tsx
@@ -1,31 +1,94 @@
-import { Box, Typography } from '@mui/material';
-import { useState } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { DiaryStyle } from 'styles/DiaryStyle';
 import { DiaryTypes } from 'utils/types';
+import { InfoOutlined } from '@mui/icons-material';
 
 interface DiaryProps {
   plantId: string | null;
 }
 
 const Diary = ({ plantId }: DiaryProps) => {
-  const [logs, setLogs] = useState<DiaryTypes>();
+  const [logs, setLogs] = useState<DiaryTypes[]>();
 
-  const fetchDiary = () => {
+  useEffect(() => {
     fetch(`/api/diary?plantId=${plantId}`, {
       method: 'GET',
     })
       .then((res) => res.json())
-      .then((data) => console.log(setLogs(data)));
-  };
-  console.log(logs);
+      .then((data) =>
+        setLogs(
+          data.map((item: DiaryTypes) => ({
+            _id: item._id,
+            content: item.content,
+            date: new Date(item.date),
+            name: item.name,
+            plantId: item.plantId,
+          }))
+        )
+      );
+  }, []);
+
+  if (logs !== undefined) {
+    logs.sort((a, b) => b.date.getTime() - a.date.getTime());
+  }
 
   return (
-    <Box sx={DiaryStyle.diaryBox}>
-      <Box sx={DiaryStyle.diarySection} onClick={fetchDiary}>
-        <Typography variant="h4" color="customBlack.main">
-          Log
-        </Typography>
-      </Box>
+    <Box>
+      {logs === undefined && (
+        <Box width="300px">
+          <CircularProgress sx={{ color: 'white' }} />
+        </Box>
+      )}
+      {logs !== undefined && (
+        <>
+          {logs.length === 0 && (
+            <Box sx={DiaryStyle.zeroLog}>
+              <InfoOutlined sx={{ fontSize: '50px', mb: 2 }} />
+              <Typography variant="h5">
+                No logs to display. Please write a diary about this plant
+              </Typography>
+            </Box>
+          )}
+          {logs.length !== 0 && (
+            <Box sx={DiaryStyle.diarySection}>
+              <Typography
+                variant="h4"
+                color="customBlack.main"
+                sx={{ textAlign: 'center' }}
+              >
+                Log
+              </Typography>
+              <Box sx={DiaryStyle.logBox}>
+                {logs.map((log, index) => {
+                  return (
+                    <Box
+                      sx={{
+                        mb: 4,
+                        '&:hover': {
+                          bgcolor: '#6d616127',
+                        },
+                        color: '#2b2828',
+                        p: 1,
+                      }}
+                      key={`log-${index}`}
+                    >
+                      <Box sx={DiaryStyle.titleDate}>
+                        <Typography variant="h6">Title : {log.name}</Typography>
+                        <Typography variant="h6">
+                          {log.date.toISOString().split('T')[0]}
+                        </Typography>
+                      </Box>
+                      <Typography variant="body1">{log.content}</Typography>
+                    </Box>
+                  );
+                })}
+                <Typography variant="h2"></Typography>
+              </Box>
+            </Box>
+          )}
+        </>
+      )}
     </Box>
   );
 };

--- a/components/features/plant/diary/DiaryBtn.tsx
+++ b/components/features/plant/diary/DiaryBtn.tsx
@@ -8,9 +8,10 @@ const DiaryBtn = () => {
   return (
     <Box
       sx={{
-        position: { xs: '', sm: 'absolute' },
-        bottom: { xs: 0, sm: 40 },
-        right: { xs: 0, sm: 40 },
+        position: { xs: '', md: 'absolute' },
+        bottom: { xs: 0, md: 40 },
+        right: { xs: 0, md: 40 },
+        mt: 1,
       }}
     >
       <Button

--- a/components/features/plant/diary/DiaryForm.tsx
+++ b/components/features/plant/diary/DiaryForm.tsx
@@ -80,7 +80,7 @@ const DiaryForm = () => {
           <Box display="flex" flexDirection="column">
             <FormControl required>
               <FormLabel sx={{ textAlign: 'start', color: 'white' }}>
-                Name
+                Title
               </FormLabel>
               <TextField
                 variant="outlined"

--- a/styles/DiaryStyle.tsx
+++ b/styles/DiaryStyle.tsx
@@ -3,5 +3,15 @@ import { SxProps, Theme } from '@mui/material';
 export const DiaryStyle: Record<string, SxProps<Theme> | undefined> = {
   diaryBox: {
     maxWidth: '800px',
+    backgroundColor: '#78b47d',
+    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  diarySection: {
+    // minWidth: '300px',
+    backgroundColor: '#f5f8e8',
+    color: 'black',
+    height: '450px',
   },
 };

--- a/styles/DiaryStyle.tsx
+++ b/styles/DiaryStyle.tsx
@@ -11,7 +11,7 @@ export const DiaryStyle: Record<string, SxProps<Theme> | undefined> = {
     scrollbarColor: '#6d6161 white',
     padding: '30px 10px',
     height: { md: '450px' },
-    minWidth: { xs: '360px', md: '400px', lg: '700px' },
+    minWidth: { xs: '85vw', md: '400px', lg: '700px' },
   },
   titleDate: {
     display: { xs: 'wrap', sm: 'flex' },

--- a/styles/DiaryStyle.tsx
+++ b/styles/DiaryStyle.tsx
@@ -1,17 +1,31 @@
 import { SxProps, Theme } from '@mui/material';
 
 export const DiaryStyle: Record<string, SxProps<Theme> | undefined> = {
-  diaryBox: {
-    maxWidth: '800px',
-    backgroundColor: '#78b47d',
-    borderRadius: '6px',
-    display: 'flex',
-    alignItems: 'center',
-  },
   diarySection: {
-    // minWidth: '300px',
-    backgroundColor: '#f5f8e8',
-    color: 'black',
-    height: '450px',
+    textAlign: 'start',
+    borderRadius: '3px',
+    backgroundColor: '#f7f6ea',
+  },
+  logBox: {
+    overflow: 'auto',
+    scrollbarColor: '#6d6161 white',
+    padding: '30px 10px',
+    height: { md: '450px' },
+    minWidth: { xs: '360px', md: '400px', lg: '700px' },
+  },
+  titleDate: {
+    display: { xs: 'wrap', sm: 'flex' },
+    justifyContent: 'space-between',
+    overflow: 'auto',
+    mb: 1,
+  },
+  zeroLog: {
+    width: '300px',
+    height: '400px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#6d61612a',
   },
 };

--- a/styles/PlantDetailStyle.tsx
+++ b/styles/PlantDetailStyle.tsx
@@ -17,7 +17,7 @@ export const PlantDetailStyle: Record<string, SxProps<Theme> | undefined> = {
   infoBox: {
     backgroundColor: '#78b47d',
     margin: '20px auto',
-    borderRadius: '6px',
+    borderRadius: { md: '6px' },
     color: 'white',
     textAlign: 'center',
     padding: 3,
@@ -33,7 +33,6 @@ export const PlantDetailStyle: Record<string, SxProps<Theme> | undefined> = {
     textAlign: 'start',
   },
   content: {
-    paddingTop: '50px',
     maxWidth: '1400px',
     position: 'absolute',
   },
@@ -47,6 +46,7 @@ export const PlantDetailStyle: Record<string, SxProps<Theme> | undefined> = {
   back: {
     position: 'relative',
     margin: 3,
+    top: { sm: 0, md: '130px' },
     backgroundColor: 'beige',
   },
 };

--- a/styles/PlantDetailStyle.tsx
+++ b/styles/PlantDetailStyle.tsx
@@ -10,35 +10,32 @@ export const PlantDetailStyle: Record<string, SxProps<Theme> | undefined> = {
   },
   header: {
     display: 'flex',
-    justifyContent: { xs: 'center', sm: 'flex-start' },
-    marginLeft: { xs: '0', sm: '0', md: '0', lg: '85px' },
-    marginBottom: '-80px',
+    justifyContent: { xs: 'center', sm: 'center', md: 'flex-start' },
+    marginLeft: { xs: '0', sm: '0', md: '80px', lg: '130px' },
+    marginBottom: '-85px',
   },
   infoBox: {
     backgroundColor: '#78b47d',
-    margin: '20px auto',
+    margin: '30px auto',
     borderRadius: { md: '6px' },
     color: 'white',
     textAlign: 'center',
     padding: 3,
     display: 'flex',
-    flexDirection: { xs: 'column', sm: 'row' },
+    flexDirection: { xs: 'column', md: 'row' },
     alignItems: 'center',
-    maxHeight: { xs: 'none', sm: '500px', md: '600px' },
+    maxHeight: { xs: 'none', sm: 'none', md: '600px' },
   },
   desc: {
     width: '90%',
     maxWidth: '600px',
-    margin: '20px auto',
+    margin: '30px auto',
     textAlign: 'start',
   },
   content: {
+    width: { sm: '100%', md: 'fit-content' },
     maxWidth: '1400px',
     position: 'absolute',
-  },
-  contextMobile: {
-    display: 'flex',
-    flexDirection: 'column',
   },
   backParent: {
     position: 'absolute',
@@ -46,7 +43,7 @@ export const PlantDetailStyle: Record<string, SxProps<Theme> | undefined> = {
   back: {
     position: 'relative',
     margin: 3,
-    top: { sm: 0, md: '130px' },
+    top: { sm: '130px', md: '130px' },
     backgroundColor: 'beige',
   },
 };

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -11,3 +11,11 @@ export type PlantsTypes = {
   category: string;
   imgName: string;
 };
+
+export type DiaryTypes = {
+  _id: {};
+  content: string;
+  date: Date;
+  name: string;
+  plantId: string;
+};


### PR DESCRIPTION
This PR implements diary of plants. It displays title, date and content of diary. If the log is empty, a notification accompanied by an icon encourages users to write a diary.
# screenshot
when there is log
![image](https://github.com/kaulfield23/Days-of-planty-next.js/assets/77925373/deeaa450-2618-41f4-800d-67c4f056ca8c)

when log is empty
![image](https://github.com/kaulfield23/Days-of-planty-next.js/assets/77925373/a44a8864-df1f-4de8-9bcb-3258a9f81d13)

Resolves #32 
Resolves #31 